### PR TITLE
fixed images

### DIFF
--- a/style.css
+++ b/style.css
@@ -178,6 +178,7 @@ input, textarea{
   flex-direction: column;
   margin-left: 5vw;
   margin-right: 5vw;
+  align-items: flex-start;
 }
 /*about page styles*/
 .section{


### PR DESCRIPTION
This fixes the aspect ratio for the images in the blog.  You will no longer need to resize images for the blog expect if they are really, really big and take up too much space. ( Note: Remember to resize/crop the profile images on the about page to make sure they don't get stretched. )